### PR TITLE
replacing mapview CRAN import with GitHub remote to avoid errors on systems running R < 3.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Imports:
     lubridate,
     maptools,
     mapproj,
-    mapview (>= 2.3.0),
     mapdata,
     mgcv,
     ncf,
@@ -50,6 +49,7 @@ Remotes:
 	github::ctmm-initiative/ctmmweb,
     github::rforge/tlocoh/pkg,
     github::16EAGLE/getSpatialData,
+    github::r-spatial/mapview,
     url::https://raw.githubusercontent.com/cbracis/mrw/master/mrw.tar.gz,
     url::https://raw.githubusercontent.com/cbracis/waddle/master/waddle.tar.gz
 License: GPL v3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Remotes:
 	github::ctmm-initiative/ctmmweb,
     github::rforge/tlocoh/pkg,
     github::16EAGLE/getSpatialData,
-    github::r-spatial/mapview,
+    github::r-spatial/mapview@develop,
     url::https://raw.githubusercontent.com/cbracis/mrw/master/mrw.tar.gz,
     url::https://raw.githubusercontent.com/cbracis/waddle/master/waddle.tar.gz
 License: GPL v3


### PR DESCRIPTION
current CRAN mapview requires R >= 3.5 (which is not indicated), since the function isFALSE newly introduced in 3.5 is used (see: https://github.com/r-spatial/mapview/issues/177). Therefore, the mapview CRAN version is partly broken on systems running R < 3.5. To not be dependent on the newest R release, the mistake was corrected and isFALSE was removed from mapview, however the version using it is still the one on CRAN. Since the current CRAN version also causes some dependent packages (including getSpatialData) to error, if R < 3.5 is running, I would suggest to replace the import with the GitHub remote for now.